### PR TITLE
Fix table name retrieval in ProductRepositoryPlugin

### DIFF
--- a/Plugin/ProductRepositoryPlugin.php
+++ b/Plugin/ProductRepositoryPlugin.php
@@ -73,7 +73,7 @@ class ProductRepositoryPlugin
 
         try {
             $connection = $this->resourceConnection->getConnection();
-            $tableName = $connection->getTableName('cataloginventory_stock_item');
+            $tableName = $this->resourceConnection->getTableName('cataloginventory_stock_item');
 
             $query = $connection->select()
                 ->from($tableName, ['product_id', 'qty', 'is_in_stock', 'manage_stock', 'backorders'])


### PR DESCRIPTION
Correctly resolve table prefix
https://github.com/magento/magento2/issues/6402

Fixes
[2025-10-20T00:51:29.477092+00:00] .ERROR: Product Plugin: Error fetching stock data: SQLSTATE[42S02]: Base table or view not found: 1146 Table 'xxx.cataloginventory_stock_item' doesn't exist, query was: SELECT `cataloginventory_stock_item`.`product_id`, `cataloginventory_stock_item`.`qty`, `cataloginventory_stock_item`.`is_in_stock`, `cataloginventory_stock_item`.`manage_stock`, `cataloginventory_stock_item`.`backorders` FROM `cataloginventory_stock_item` WHERE (product_id IN (xxx)) [] []